### PR TITLE
Startup optimizations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,11 @@
 FROM sonatype/nexus3
 
 COPY . /scripts
+RUN chmod +x /scripts/*
 
 ENV ADMIN_PASSWORD="admin123"
 
-# Add a healtcheck with default options except for the start-period.
-# The 90s is the amount of sleep we are running in the start.sh script
-
-HEALTHCHECK --start-period=90s --interval=30s --timeout=30s --retries=3 \
-  CMD curl -f http://localhost:8081/service/rest/v1/status/writable || exit
+HEALTHCHECK --start-period=60s --interval=15s --timeout=15s --retries=3 \
+  CMD /scripts/health.sh || exit
 
 CMD ["sh", "-c", "/scripts/start.sh"]

--- a/health.sh
+++ b/health.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+if test -f "/tmp/starting_nexus"; then
+  # Starting file is still there so not healthy
+  exit 1
+fi
+
+curl -s -f http://localhost:8081/service/rest/v1/status/writable
+exit $?


### PR DESCRIPTION
The following changes shouls make the container start faster and since
Github Actions use the HEALTHCHECK we will now not start the workflow
until Nexus is started and configured:

- start.sh doesn't use the sleep command with fixed values, now polls
the API /status/writable endpoint
- start.sh writes a temp file when start for use in the health.sh
- Dockerfile HEALTHCHECK now calls a new health.sh script
- health.sh check for either the temp file create by the start.sh or the
API /status/writable endpoint

Fixes: #3