### PR TITLE
Increase image start-period

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ COPY . /scripts
 
 ENV ADMIN_PASSWORD="admin123"
 
-HEALTHCHECK --start-period=60s --interval=15s --timeout=15s --retries=3 \
+HEALTHCHECK --start-period=120s --interval=15s --timeout=15s --retries=3 \
   CMD /scripts/health.sh || exit
 
 CMD ["sh", "-c", "/scripts/start.sh"]


### PR DESCRIPTION
We need a long start-period otherwise Github Actions migth get an un-healthy status back. It takes about 90 seconds to start Nexus so with 120 we should be fine. If a healthy status is returned in the start-period it will work, only unhealthy status are ignored during the start-period